### PR TITLE
Take out https:// from insert link and insert image snippets

### DIFF
--- a/snippets/quarto.code-snippets
+++ b/snippets/quarto.code-snippets
@@ -98,12 +98,12 @@
   },
   "Insert link": {
     "prefix": "link",
-    "body": "[${TM_SELECTED_TEXT:${1:text}}](https://${2:link})$0",
+    "body": "[${TM_SELECTED_TEXT:${1:text}}](${2:link})$0",
     "description": "Insert link"
   },
   "Insert image": {
     "prefix": "image",
-    "body": "![${TM_SELECTED_TEXT:${1:alt}}](https://${2:link})$0",
+    "body": "![${TM_SELECTED_TEXT:${1:alt}}](${2:link})$0",
     "description": "Insert image"
   },
   "Insert strikethrough": {


### PR DESCRIPTION
`http://` is hard-coded in both snippets. Since images and links are not always in `http`, let's take this out.