### PR TITLE
Fix LaTeX equation in Walkthrough Document

### DIFF
--- a/src/providers/walkthrough.ts
+++ b/src/providers/walkthrough.ts
@@ -115,7 +115,7 @@ ${langBlock.code}
 Use LaTeX to write equations:
 
 $$
-chi' = sum_{i=1}^n k_i s_i^2
+\\chi' = \\sum_{i=1}^n k_i s_i^2
 $$
 `;
   }


### PR DESCRIPTION
Walkthrough file pulls:

$$
chi' = sum_{i=1}^n k_i s_i^2
$$

Thus, when rendering the preview, one would get: 

<img width="299" alt="Broken equation" src="https://user-images.githubusercontent.com/833642/183519082-1213913b-b7d1-4ea2-9ed8-bd15e68c9920.png">

Adding in a backslash with an escape character should yield:

$$
\chi' = \sum_{i=1}^n k_i s_i^2
$$


<img width="297" alt="Fixed Equation" src="https://user-images.githubusercontent.com/833642/183519099-a7f3aa41-fe3e-4876-8dcd-0d4fff95c0f7.png">

