### PR TITLE
ci: auto tag and release on 'release vX.X.X' commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set version from commit message
         id: tag_id
+        env:
+          VAR: ${{ github.event.head_commit.message }}
         run: |
-          VAR="${{ github.event.head_commit.message }}"
           TAG="${VAR#* }"
           echo ::set-output name=tag::"${TAG}"
           echo "${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    branches: main
+
+name: Release
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.head_commit.message, 'release')
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set version from commit message
+        id: tag_id
+        run: |
+          VAR="${{ github.event.head_commit.message }}"
+          TAG="${VAR#* }"
+          echo ::set-output name=tag::"${TAG}"
+          echo "${TAG}"
+      - name: Set release name
+        id: release_id
+        run: |
+          echo ::set-output name=releasename::"${{ steps.tag_id.outputs.tag }}"
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          custom_tag: ${{ steps.tag_id.outputs.tag }}
+          tag_prefix: ""
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: ${{ steps.release_id.outputs.releasename }}
+          generateReleaseNotes: true
+          allowUpdates: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR proposes a GitHub Action to tag and make a GitHub release with GitHub changelog on commits following the pattern 'release vX.X.X'.
GHA is triggered by a commit message starting with 'release'.
Tag/Release name are set with anything after 'release ', i.e., from 'release vX.X.X' commit message, the tag will be 'vX.X.X'.

Fixes #58