### PR TITLE
fix: consistent naming across render function/button

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here is a complete list of the supported render commands:
 - Quarto: Render
 - Quarto: Render HTML
 - Quarto: Render PDF
-- Quarto: Render Word
+- Quarto: Render DOCX
 
 The **Quarto: Render** command renders the default format of the
 currently active document. The other commands render specific formats

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "onCommand:quarto.render",
     "onCommand:quarto.renderHTML",
     "onCommand:quarto.renderPDF",
-    "onCommand:quarto.renderWord",
+    "onCommand:quarto.renderDOCX",
     "onCommand:quarto.renderShortcut",
     "onCommand:quarto.newDocument",
     "onCommand:quarto.fileNewDocument",
@@ -269,8 +269,8 @@
         "category": "Quarto"
       },
       {
-        "command": "quarto.renderWord",
-        "title": "Render Word",
+        "command": "quarto.renderDOCX",
+        "title": "Render DOCX",
         "category": "Quarto"
       },
       {
@@ -466,7 +466,7 @@
           "when": "editorLangId == quarto"
         },
         {
-          "command": "quarto.renderWord",
+          "command": "quarto.renderDOCX",
           "when": "editorLangId == quarto"
         },
         {
@@ -485,7 +485,7 @@
           "command": "quarto.renderPDF"
         },
         {
-          "command": "quarto.renderWord"
+          "command": "quarto.renderDOCX"
         }
       ],
       "file/newFile": [
@@ -552,7 +552,7 @@
           "when": "editorLangId == quarto"
         },
         {
-          "command": "quarto.renderWord",
+          "command": "quarto.renderDOCX",
           "when": "editorLangId == quarto"
         },
         {

--- a/src/providers/preview/commands.ts
+++ b/src/providers/preview/commands.ts
@@ -26,7 +26,7 @@ export function previewCommands(
     new RenderShortcutCommand(quartoContext, engine),
     new RenderDocumentHTMLCommand(quartoContext, engine),
     new RenderDocumentPDFCommand(quartoContext, engine),
-    new RenderDocumentWordCommand(quartoContext, engine),
+    new RenderDocumentDOCXCommand(quartoContext, engine),
     new RenderProjectCommand(quartoContext),
     new WalkthroughRenderCommand(quartoContext, engine),
     new ClearCacheCommand(),
@@ -143,15 +143,15 @@ class RenderDocumentPDFCommand
   }
 }
 
-class RenderDocumentWordCommand
+class RenderDocumentDOCXCommand
   extends RenderDocumentCommandBase
   implements Command
 {
   constructor(quartoContext: QuartoContext, engine: MarkdownEngine) {
     super(quartoContext, engine);
   }
-  private static readonly id = "quarto.renderWord";
-  public readonly id = RenderDocumentWordCommand.id;
+  private static readonly id = "quarto.renderDOCX";
+  public readonly id = RenderDocumentDOCXCommand.id;
 
   protected async doExecute() {
     return super.renderFormat("docx");


### PR DESCRIPTION
This PR proposes a change in the "render Word" button and related function to make it consistent with the other button/formats, i.e., "PDF" and "HTML" are the formats, while "Word" is the software, thus "DOCX" would be the consistent name.
This could also help clarify that this is the formats not a type of document.

Partially related to some of the following discussion: https://github.com/quarto-dev/quarto-cli/discussions/2234