### PR TITLE
Patch Quarto lens accessibility

### DIFF
--- a/src/providers/assist/render-assist.ts
+++ b/src/providers/assist/render-assist.ts
@@ -51,7 +51,7 @@ export function renderWebviewHtml(webview: Webview, extensionUri: Uri) {
       <title>Quarto Lens</title>
     </head>
     <body>
-      <article id="main" role="document"></article>
+      <article id="main" role="document" tabindex="0"></article>
 
       <script nonce="${nonce}" src="${scriptUri}"></script>
     </body>


### PR DESCRIPTION
Mistakenly forgot to add tabindex attribute to Quarto Lens `<article>` tag with `document` role. Without `tabindex`, screen reader's virtual cursor (AKA browse mode) is not auto-activated.