### PR TITLE
KICENSE => LICENSE

### DIFF
--- a/src/providers/preview/preview-env.ts
+++ b/src/providers/preview/preview-env.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) RStudio, PBC. All rights reserved.
- *  Licensed under the MIT License. See KICENSE in the project root for license information.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as os from "os";

--- a/src/providers/preview/preview-errors.ts
+++ b/src/providers/preview/preview-errors.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) RStudio, PBC. All rights reserved.
- *  Licensed under the MIT License. See KICENSE in the project root for license information.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from "path";

--- a/src/providers/preview/preview-output.ts
+++ b/src/providers/preview/preview-output.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) RStudio, PBC. All rights reserved.
- *  Licensed under the MIT License. See KICENSE in the project root for license information.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as tmp from "tmp";

--- a/src/providers/preview/preview-reveal.ts
+++ b/src/providers/preview/preview-reveal.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) RStudio, PBC. All rights reserved.
- *  Licensed under the MIT License. See KICENSE in the project root for license information.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import { Position, TextDocument } from "vscode";

--- a/src/providers/preview/preview-util.ts
+++ b/src/providers/preview/preview-util.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) RStudio, PBC. All rights reserved.
- *  Licensed under the MIT License. See KICENSE in the project root for license information.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from "path";

--- a/src/providers/preview/preview-webview.ts
+++ b/src/providers/preview/preview-webview.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) RStudio, PBC. All rights reserved.
- *  Licensed under the MIT License. See KICENSE in the project root for license information.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import {

--- a/src/providers/webview.ts
+++ b/src/providers/webview.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) RStudio, PBC. All rights reserved.
  *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See KICENSE in the project root for license information.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import {


### PR DESCRIPTION
Fixing a spelling mistake that appears in a couple copyright headers.